### PR TITLE
replace `Add`/`Sub` with `Mul`/`Div` for `Unit<...>`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,10 +44,10 @@ macro_rules! Unit {
         Unit![@exp $t => $op; $a ^ $n; $( $tts )*]
     };
     ($t:ty => * $a:ident $( $tts:tt )*) => {
-        Unit![<$t as core::ops::Add<$a>>::Output => $( $tts )*]
+        Unit![<$t as core::ops::Mul<$a>>::Output => $( $tts )*]
     };
     ($t:ty => / $a:ident $( $tts:tt )*) => {
-        Unit![<$t as core::ops::Sub<$a>>::Output => $( $tts )*]
+        Unit![<$t as core::ops::Div<$a>>::Output => $( $tts )*]
     };
     ($t:ident $( $tts:tt )*) => {
         Unit![$crate::units::Dimensionless => * $t $( $tts )*]

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -222,10 +222,10 @@ where
 impl<S, U0, U1> Mul<Quantity<S, U1>> for Quantity<S, U0>
 where
     S: Mul<Output = S>,
-    U0: UnitTrait + Add<U1>,
+    U0: UnitTrait + Mul<U1>,
     U1: UnitTrait,
 {
-    type Output = Quantity<S, <U0 as Add<U1>>::Output>;
+    type Output = Quantity<S, <U0 as Mul<U1>>::Output>;
 
     #[inline]
     fn mul(self, rhs: Quantity<S, U1>) -> Self::Output {
@@ -243,10 +243,10 @@ where
 impl<S, U0, U1> Div<Quantity<S, U1>> for Quantity<S, U0>
 where
     S: Div<Output = S>,
-    U0: UnitTrait + Sub<U1>,
+    U0: UnitTrait + Div<U1>,
     U1: UnitTrait,
 {
-    type Output = Quantity<S, <U0 as Sub<U1>>::Output>;
+    type Output = Quantity<S, <U0 as Div<U1>>::Output>;
 
     #[inline]
     fn div(self, rhs: Quantity<S, U1>) -> Self::Output {
@@ -351,7 +351,7 @@ where
 impl<S, U0, U1> CheckedMul<Quantity<S, U1>> for Quantity<S, U0>
 where
     S: CheckedMul<Output = S>,
-    U0: UnitTrait + Add<U1>,
+    U0: UnitTrait + Mul<U1>,
     U1: UnitTrait,
 {
     #[inline]
@@ -371,7 +371,7 @@ where
 impl<S, U0, U1> CheckedDiv<Quantity<S, U1>> for Quantity<S, U0>
 where
     S: CheckedDiv<Output = S>,
-    U0: UnitTrait + Sub<U1>,
+    U0: UnitTrait + Div<U1>,
     U1: UnitTrait,
 {
     #[inline]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2,7 +2,7 @@ use core::{
     any::type_name,
     fmt::{Debug, Error, Formatter},
     marker::PhantomData,
-    ops::{Add, Sub},
+    ops::{Add, Div, Mul, Sub},
 };
 
 /// Trait implemented for [`Unit`].
@@ -112,7 +112,7 @@ impl<L, M, T, I, O, N, J> Copy for Unit<L, M, T, I, O, N, J> {}
 /// `Unit<1, 0, -1, ...> + Unit<0, 0, 1, ...> = Unit<1, 0, 0, ...>`
 ///
 /// It's used for multiplying quantities.
-impl<U, L, M, T, I, O, N, J> Add<U> for Unit<L, M, T, I, O, N, J>
+impl<U, L, M, T, I, O, N, J> Mul<U> for Unit<L, M, T, I, O, N, J>
 where
     U: UnitTrait,
     L: Add<U::Length>,
@@ -135,7 +135,7 @@ where
     >;
 
     #[inline]
-    fn add(self, _rhs: U) -> Self::Output {
+    fn mul(self, _rhs: U) -> Self::Output {
         Unit::new()
     }
 }
@@ -144,7 +144,7 @@ where
 /// `Unit<1, 0, -1, ...> - Unit<0, 0, 1, ...> = Unit<1, 0, -2, ...>`
 ///
 /// It's used for dividing quantities.
-impl<U, L, M, T, I, O, N, J> Sub<U> for Unit<L, M, T, I, O, N, J>
+impl<U, L, M, T, I, O, N, J> Div<U> for Unit<L, M, T, I, O, N, J>
 where
     U: UnitTrait,
     L: Sub<U::Length>,
@@ -168,7 +168,7 @@ where
     >;
 
     #[inline]
-    fn sub(self, _rhs: U) -> Self::Output {
+    fn div(self, _rhs: U) -> Self::Output {
         Unit::new()
     }
 }
@@ -195,20 +195,20 @@ mod tests {
     }
 
     #[test]
-    fn sub() {
+    fn div() {
         let _: Unit<Z0, Z0, Z0, Z0, Z0, Z0, Z0> =
-            Unit::<P1, P1, P1, P1, P1, P1, P1>::new() - Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
+            Unit::<P1, P1, P1, P1, P1, P1, P1>::new() / Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
 
         let _: Unit<N8, N7, N6, N5, N4, N3, N2> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() - Unit::<P8, P7, P6, P5, P4, P3, P2>::new();
+            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() / Unit::<P8, P7, P6, P5, P4, P3, P2>::new();
     }
 
     #[test]
-    fn add() {
+    fn mul() {
         let _: Unit<P1, P1, P1, P1, P1, P1, P1> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() + Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
+            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
 
         let _: Unit<P8, N7, P6, N5, P4, N3, P2> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() + Unit::<P8, N7, P6, N5, P4, N3, P2>::new();
+            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Unit::<P8, N7, P6, N5, P4, N3, P2>::new();
     }
 }


### PR DESCRIPTION
Replace implementations for `Unit<...>`: `core::ops::{Add => Mul, Sub => Div}`.
Previously there were `Add`/`Sub` because exponents of the unit are added/subtracted.
But actually _units_ are multiplied/divided, so it's more logical to implement
`Mul`/`Div`. Also this change makes bounds in `Quantity<_, _>` a bit easier to
read and understand.