### PR TITLE
move dimensions from `Unit` into `Dimensions`

### DIFF
--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -60,7 +60,8 @@ impl<L, M, T, I, O, N, J> DimensionsTrait for Dimensions<L, M, T, I, O, N, J> {
     type LuminousIntensity = J;
 }
 
-/// Represent dimensions of a unit at type level by storing exponents of the [base units]:
+/// Represent dimensions of a unit at type level by storing exponents of the
+/// [base units]:
 ///
 /// - `L`, Length
 /// - `M`, Mass
@@ -71,12 +72,12 @@ impl<L, M, T, I, O, N, J> DimensionsTrait for Dimensions<L, M, T, I, O, N, J> {
 /// - `J` Luminous intensity
 ///
 /// Examples:
-/// - `Dimensions<P1, Z0, Z0, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁰ * ...` is `m` is
-///   metre (length).
-/// - `Dimensions<Z0, Z0, P1, Z0, Z0, Z0, Z0>` is `m⁰ * kg⁰ * s¹ * ...` is `s` is
-///   second (time).
-/// - `Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m * s⁻¹`
-///   is `m / s` metre per second (speed)
+/// - `Dimensions<P1, Z0, Z0, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁰ * ...` is `m`
+///   is metre (length).
+/// - `Dimensions<Z0, Z0, P1, Z0, Z0, Z0, Z0>` is `m⁰ * kg⁰ * s¹ * ...` is `s`
+///   is second (time).
+/// - `Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m *
+///   s⁻¹` is `m / s` metre per second (speed)
 ///
 /// [base units]: https://en.wikipedia.org/wiki/SI_base_unit
 #[allow(clippy::type_complexity)]
@@ -107,7 +108,8 @@ impl<L, M, T, I, O, N, J> Clone for Dimensions<L, M, T, I, O, N, J> {
 impl<L, M, T, I, O, N, J> Copy for Dimensions<L, M, T, I, O, N, J> {}
 
 /// This adds exponents at type-level. E.g.
-/// `Dimensions<1, 0, -1, ...> * Dimensions<0, 0, 1, ...> = /// Dimensions<1, 0, 0, ...>`
+/// `Dimensions<1, 0, -1, ...> * Dimensions<0, 0, 1, ...> =
+/// Dimensions<1, 0, 0, ...>`
 ///
 /// It's used for multiplying quantities.
 impl<U, L, M, T, I, O, N, J> Mul<U> for Dimensions<L, M, T, I, O, N, J>
@@ -196,18 +198,22 @@ mod tests {
     #[test]
     fn div() {
         let _: Dimensions<Z0, Z0, Z0, Z0, Z0, Z0, Z0> =
-            Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new() / Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
+            Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new()
+                / Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
 
         let _: Dimensions<N8, N7, N6, N5, N4, N3, N2> =
-            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() / Dimensions::<P8, P7, P6, P5, P4, P3, P2>::new();
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new()
+                / Dimensions::<P8, P7, P6, P5, P4, P3, P2>::new();
     }
 
     #[test]
     fn mul() {
         let _: Dimensions<P1, P1, P1, P1, P1, P1, P1> =
-            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new()
+                * Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
 
         let _: Dimensions<P8, N7, P6, N5, P4, N3, P2> =
-            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Dimensions::<P8, N7, P6, N5, P4, N3, P2>::new();
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new()
+                * Dimensions::<P8, N7, P6, N5, P4, N3, P2>::new();
     }
 }

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -1,0 +1,213 @@
+use core::{
+    any::type_name,
+    fmt::{Debug, Error, Formatter},
+    marker::PhantomData,
+    ops::{Add, Div, Mul, Sub},
+};
+
+use crate::TypeOnly;
+
+/// Trait implemented for [`Dimensions`].
+/// Mostly needed to simplify bound and write
+/// ```
+/// # use typed_phy::DimensionsTrait;
+/// # trait Trait {}
+/// impl<U: DimensionsTrait> Trait for U {
+///     /* ... */
+/// }
+/// ```
+/// Instead of
+/// ```
+/// # use typed_phy::Dimensions;
+/// # trait Trait {}
+/// impl<L, M, T, I, O, N, J> Trait for Dimensions<L, M, T, I, O, N, J> {
+///     /* ... */
+/// }
+/// ```
+///
+/// [`Dimesnsions`]: struct@Dimensions
+pub trait DimensionsTrait {
+    /// Length, base unit: metre
+    type Length;
+
+    /// Mass, base unit: kilogram
+    type Mass;
+
+    /// Time, base unit: second
+    type Time;
+
+    /// Electric current, base unit: ampere
+    type ElectricCurrent;
+
+    /// Thermodynamic temperature, base unit: kelvin
+    type ThermodynamicTemperature;
+
+    /// Amount of substance, base unit: mole
+    type AmountOfSubstance;
+
+    /// Luminous intensity, base unit: candela
+    type LuminousIntensity;
+}
+
+#[rustfmt::skip] // I don't want assoc types to be reordered
+impl<L, M, T, I, O, N, J> DimensionsTrait for Dimensions<L, M, T, I, O, N, J> {
+    type Length = L;
+    type Mass = M;
+    type Time = T;
+    type ElectricCurrent = I;
+    type ThermodynamicTemperature = O;
+    type AmountOfSubstance = N;
+    type LuminousIntensity = J;
+}
+
+/// Represent dimensions of a unit at type level by storing exponents of the [base units]:
+///
+/// - `L`, Length
+/// - `M`, Mass
+/// - `T`, Time
+/// - `I`, Electric current
+/// - `O` Thermodynamic temperature
+/// - `N` Amount of substance
+/// - `J` Luminous intensity
+///
+/// Examples:
+/// - `Dimensions<P1, Z0, Z0, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁰ * ...` is `m` is
+///   metre (length).
+/// - `Dimensions<Z0, Z0, P1, Z0, Z0, Z0, Z0>` is `m⁰ * kg⁰ * s¹ * ...` is `s` is
+///   second (time).
+/// - `Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m * s⁻¹`
+///   is `m / s` metre per second (speed)
+///
+/// [base units]: https://en.wikipedia.org/wiki/SI_base_unit
+#[allow(clippy::type_complexity)]
+pub struct Dimensions<L, M, T, I, O, N, J>(TypeOnly<(L, M, T, I, O, N, J)>);
+
+impl<L, M, T, I, O, N, J> Dimensions<L, M, T, I, O, N, J> {
+    pub(crate) fn new() -> Self {
+        Self(PhantomData::default())
+    }
+}
+
+// We need to use handwritten impls to prevent unnecessary bounds on generics
+impl<L, M, T, I, O, N, J> Debug for Dimensions<L, M, T, I, O, N, J> {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // TODO: add options to human-readable format
+        f.pad(type_name::<Self>())
+    }
+}
+
+impl<L, M, T, I, O, N, J> Clone for Dimensions<L, M, T, I, O, N, J> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl<L, M, T, I, O, N, J> Copy for Dimensions<L, M, T, I, O, N, J> {}
+
+/// This adds exponents at type-level. E.g.
+/// `Dimensions<1, 0, -1, ...> * Dimensions<0, 0, 1, ...> = /// Dimensions<1, 0, 0, ...>`
+///
+/// It's used for multiplying quantities.
+impl<U, L, M, T, I, O, N, J> Mul<U> for Dimensions<L, M, T, I, O, N, J>
+where
+    U: DimensionsTrait,
+    L: Add<U::Length>,
+    M: Add<U::Mass>,
+    T: Add<U::Time>,
+    I: Add<U::ElectricCurrent>,
+    O: Add<U::ThermodynamicTemperature>,
+    N: Add<U::AmountOfSubstance>,
+    J: Add<U::LuminousIntensity>,
+{
+    #[allow(clippy::type_complexity)]
+    type Output = Dimensions<
+        <L as Add<U::Length>>::Output,
+        <M as Add<U::Mass>>::Output,
+        <T as Add<U::Time>>::Output,
+        <I as Add<U::ElectricCurrent>>::Output,
+        <O as Add<U::ThermodynamicTemperature>>::Output,
+        <N as Add<U::AmountOfSubstance>>::Output,
+        <J as Add<U::LuminousIntensity>>::Output,
+    >;
+
+    #[inline]
+    fn mul(self, _rhs: U) -> Self::Output {
+        Dimensions::new()
+    }
+}
+
+/// This subs exponents and divides ratios at type-level. E.g.
+/// `Dimensions<1, 0, -1, ..., 1/10> / Dimensions<0, 0, 1, ..., 10/1> =
+/// Dimensions<1, 0, -2, ..., 1/100>`
+///
+/// It's used for dividing quantities.
+impl<U, L, M, T, I, O, N, J> Div<U> for Dimensions<L, M, T, I, O, N, J>
+where
+    U: DimensionsTrait,
+    L: Sub<U::Length>,
+    M: Sub<U::Mass>,
+    T: Sub<U::Time>,
+    I: Sub<U::ElectricCurrent>,
+    O: Sub<U::ThermodynamicTemperature>,
+    N: Sub<U::AmountOfSubstance>,
+    J: Sub<U::LuminousIntensity>,
+{
+    // Yeah, it's very complex, but I can't do anything with it :(
+    #[allow(clippy::type_complexity)]
+    type Output = Dimensions<
+        <L as Sub<U::Length>>::Output,
+        <M as Sub<U::Mass>>::Output,
+        <T as Sub<U::Time>>::Output,
+        <I as Sub<U::ElectricCurrent>>::Output,
+        <O as Sub<U::ThermodynamicTemperature>>::Output,
+        <N as Sub<U::AmountOfSubstance>>::Output,
+        <J as Sub<U::LuminousIntensity>>::Output,
+    >;
+
+    #[inline]
+    fn div(self, _rhs: U) -> Self::Output {
+        Dimensions::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Debug;
+
+    use typenum::{N2, N3, N4, N5, N6, N7, N8, P1, P2, P3, P4, P5, P6, P7, P8, Z0};
+
+    use super::Dimensions;
+
+    /// Test that `Dimensions` implement `Debug + Clone + Copy`
+    /// even if generic parameters don't.
+    #[test]
+    #[allow(dead_code)]
+    fn traits() {
+        fn assert_bounds<T: Debug + Clone + Copy>(_: T) {}
+
+        fn check<L, M, T, I, O, N, J /* no bounds */>() {
+            // check that traits are implemented for any generics
+            assert_bounds(Dimensions::<L, M, T, I, O, N, J>::new())
+        }
+    }
+
+    #[test]
+    fn div() {
+        let _: Dimensions<Z0, Z0, Z0, Z0, Z0, Z0, Z0> =
+            Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new() / Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
+
+        let _: Dimensions<N8, N7, N6, N5, N4, N3, N2> =
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() / Dimensions::<P8, P7, P6, P5, P4, P3, P2>::new();
+    }
+
+    #[test]
+    fn mul() {
+        let _: Dimensions<P1, P1, P1, P1, P1, P1, P1> =
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Dimensions::<P1, P1, P1, P1, P1, P1, P1>::new();
+
+        let _: Dimensions<P8, N7, P6, N5, P4, N3, P2> =
+            Dimensions::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Dimensions::<P8, N7, P6, N5, P4, N3, P2>::new();
+    }
+}

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -16,9 +16,8 @@ pub trait FractionEq<Rhs>: sealed::FractionEq<Rhs> {}
 impl<T: sealed::FractionEq<Rhs>, Rhs> FractionEq<Rhs> for T {}
 
 mod sealed {
-    use crate::fraction::Fraction;
+    use crate::{fraction::Fraction, DimensionsTrait, UnitTrait};
     use core::ops::Mul;
-    use crate::{UnitTrait, DimensionsTrait};
 
     pub trait UnitEq<Rhs> {}
 
@@ -28,7 +27,8 @@ mod sealed {
         Rhs: UnitTrait,
         U::Dimensions: super::DimensionsEq<Rhs::Dimensions>,
         U::Ratio: super::FractionEq<Rhs::Ratio>,
-    {}
+    {
+    }
 
     pub trait DimensionsEq<Rhs> {}
 
@@ -43,10 +43,9 @@ mod sealed {
             ThermodynamicTemperature = D::ThermodynamicTemperature,
             AmountOfSubstance = D::AmountOfSubstance,
             LuminousIntensity = D::LuminousIntensity,
-        >
-    {}
-
-
+        >,
+    {
+    }
 
     pub trait FractionEq<Rhs> {}
 

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -1,47 +1,52 @@
-use crate::unit::UnitTrait;
+/// Represent equality of 2 units by equality of their exponents (dimensions)
+/// and equality of their ratios
+pub trait UnitEq<Rhs>: sealed::UnitEq<Rhs> {}
+
+impl<U: sealed::UnitEq<Rhs>, Rhs> UnitEq<Rhs> for U {}
 
 /// Represent equality of 2 units by equality of their exponents (dimensions)
 /// and equality of their ratios
-pub trait UnitEq<Rhs>
-where
-    Self: UnitTrait,
-    Rhs: UnitTrait<
-        Length = Self::Length,
-        Mass = Self::Mass,
-        Time = Self::Time,
-        ElectricCurrent = Self::ElectricCurrent,
-        ThermodynamicTemperature = Self::ThermodynamicTemperature,
-        AmountOfSubstance = Self::AmountOfSubstance,
-        LuminousIntensity = Self::LuminousIntensity,
-    >,
-    Self::Ratio: FractionEq<Rhs::Ratio>,
-{
-}
+pub trait DimensionsEq<Rhs>: sealed::DimensionsEq<Rhs> {}
 
-impl<U, Rhs> UnitEq<Rhs> for U
-where
-    U: UnitTrait,
-    Rhs: UnitTrait<
-        Length = U::Length,
-        Mass = U::Mass,
-        Time = U::Time,
-        ElectricCurrent = U::ElectricCurrent,
-        ThermodynamicTemperature = U::ThermodynamicTemperature,
-        AmountOfSubstance = U::AmountOfSubstance,
-        LuminousIntensity = U::LuminousIntensity,
-    >,
-    U::Ratio: FractionEq<Rhs::Ratio>,
-{
-}
+impl<D: sealed::DimensionsEq<Rhs>, Rhs> DimensionsEq<Rhs> for D {}
 
 /// Represent equality of 2 fractions
 pub trait FractionEq<Rhs>: sealed::FractionEq<Rhs> {}
 
-impl<T, Rhs> FractionEq<Rhs> for T where T: sealed::FractionEq<Rhs> {}
+impl<T: sealed::FractionEq<Rhs>, Rhs> FractionEq<Rhs> for T {}
 
 mod sealed {
     use crate::fraction::Fraction;
     use core::ops::Mul;
+    use crate::{UnitTrait, DimensionsTrait};
+
+    pub trait UnitEq<Rhs> {}
+
+    impl<U, Rhs> UnitEq<Rhs> for U
+    where
+        U: UnitTrait,
+        Rhs: UnitTrait,
+        U::Dimensions: super::DimensionsEq<Rhs::Dimensions>,
+        U::Ratio: super::FractionEq<Rhs::Ratio>,
+    {}
+
+    pub trait DimensionsEq<Rhs> {}
+
+    impl<D, Rhs> DimensionsEq<Rhs> for D
+    where
+        D: DimensionsTrait,
+        Rhs: DimensionsTrait<
+            Length = D::Length,
+            Mass = D::Mass,
+            Time = D::Time,
+            ElectricCurrent = D::ElectricCurrent,
+            ThermodynamicTemperature = D::ThermodynamicTemperature,
+            AmountOfSubstance = D::AmountOfSubstance,
+            LuminousIntensity = D::LuminousIntensity,
+        >
+    {}
+
+
 
     pub trait FractionEq<Rhs> {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod ext;
 mod id;
 mod quantity;
 mod unit;
+mod dimensions;
 
 pub use self::{
     eq::{FractionEq, UnitEq},
@@ -88,6 +89,7 @@ pub use self::{
     id::Id,
     quantity::Quantity,
     unit::{Unit, UnitTrait},
+    dimensions::{Dimensions, DimensionsTrait},
 };
 
 /// Invariant over `T` and doesn't own it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,20 +76,20 @@ pub mod simplify;
 pub mod units;
 
 /* private, but reexported */
+mod dimensions;
 mod eq;
 mod ext;
 mod id;
 mod quantity;
 mod unit;
-mod dimensions;
 
 pub use self::{
+    dimensions::{Dimensions, DimensionsTrait},
     eq::{FractionEq, UnitEq},
     ext::IntExt,
     id::Id,
     quantity::Quantity,
     unit::{Unit, UnitTrait},
-    dimensions::{Dimensions, DimensionsTrait},
 };
 
 /// Invariant over `T` and doesn't own it.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -128,12 +128,15 @@ fn unit() {
         fraction::Fraction,
         prefixes::Kilo,
         units::{Hour, KiloGram, Metre, Second, Watt},
-        IntExt, Quantity, Unit, Dimensions,
+        Dimensions, IntExt, Quantity, Unit,
     };
 
     type U3600 = <U36 as Mul<U100>>::Output;
 
-    typenum::assert_type_eq!(Unit![Kilo<Metre> / Hour], Unit<Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>, Fraction<U1000, U3600>>);
+    typenum::assert_type_eq!(
+        Unit![Kilo<Metre> / Hour],
+        Unit<Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>, Fraction<U1000, U3600>>
+    );
 
     // was broken in first version of the Unit! macro with types support
     #[allow(clippy::type_complexity)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -128,12 +128,12 @@ fn unit() {
         fraction::Fraction,
         prefixes::Kilo,
         units::{Hour, KiloGram, Metre, Second, Watt},
-        IntExt, Quantity, Unit,
+        IntExt, Quantity, Unit, Dimensions,
     };
 
     type U3600 = <U36 as Mul<U100>>::Output;
 
-    typenum::assert_type_eq!(Unit![Kilo<Metre> / Hour], Unit<P1, Z0, N1, Z0, Z0, Z0, Z0, Fraction<U1000, U3600>>);
+    typenum::assert_type_eq!(Unit![Kilo<Metre> / Hour], Unit<Dimensions<P1, Z0, N1, Z0, Z0, Z0, Z0>, Fraction<U1000, U3600>>);
 
     // was broken in first version of the Unit! macro with types support
     #[allow(clippy::type_complexity)]

--- a/src/prefixes.rs
+++ b/src/prefixes.rs
@@ -74,24 +74,12 @@ pub type Yocto<U> = DivPow10<U, U24>;
 
 /// Multiplies ratio of `U` by `X`
 pub(crate) type MulBy<U, X> = Unit<
-    <U as UnitTrait>::Length,
-    <U as UnitTrait>::Mass,
-    <U as UnitTrait>::Time,
-    <U as UnitTrait>::ElectricCurrent,
-    <U as UnitTrait>::ThermodynamicTemperature,
-    <U as UnitTrait>::AmountOfSubstance,
-    <U as UnitTrait>::LuminousIntensity,
+    <U as UnitTrait>::Dimensions,
     <<U as UnitTrait>::Ratio as Mul<Frac![X / U1]>>::Output,
 >;
 
 /// Divides ratio of `U` by `X`
 pub(crate) type DivBy<U, X> = Unit<
-    <U as UnitTrait>::Length,
-    <U as UnitTrait>::Mass,
-    <U as UnitTrait>::Time,
-    <U as UnitTrait>::ElectricCurrent,
-    <U as UnitTrait>::ThermodynamicTemperature,
-    <U as UnitTrait>::AmountOfSubstance,
-    <U as UnitTrait>::LuminousIntensity,
+    <U as UnitTrait>::Dimensions,
     <<U as UnitTrait>::Ratio as Div<Frac![X / U1]>>::Output,
 >;

--- a/src/prefixes.rs
+++ b/src/prefixes.rs
@@ -73,13 +73,9 @@ pub type Zepto<U> = DivPow10<U, U21>;
 pub type Yocto<U> = DivPow10<U, U24>;
 
 /// Multiplies ratio of `U` by `X`
-pub(crate) type MulBy<U, X> = Unit<
-    <U as UnitTrait>::Dimensions,
-    <<U as UnitTrait>::Ratio as Mul<Frac![X / U1]>>::Output,
->;
+pub(crate) type MulBy<U, X> =
+    Unit<<U as UnitTrait>::Dimensions, <<U as UnitTrait>::Ratio as Mul<Frac![X / U1]>>::Output>;
 
 /// Divides ratio of `U` by `X`
-pub(crate) type DivBy<U, X> = Unit<
-    <U as UnitTrait>::Dimensions,
-    <<U as UnitTrait>::Ratio as Div<Frac![X / U1]>>::Output,
->;
+pub(crate) type DivBy<U, X> =
+    Unit<<U as UnitTrait>::Dimensions, <<U as UnitTrait>::Ratio as Div<Frac![X / U1]>>::Output>;

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -6,8 +6,16 @@ use core::{
     ops::{Add, Div, Mul, Neg, Sub},
 };
 
-use crate::{checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub}, fraction::{FractionTrait, One}, from_int::FromUnsigned, id::Id, unit::UnitTrait, units::Dimensionless, Unit};
-use crate::eq::DimensionsEq;
+use crate::{
+    checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
+    eq::DimensionsEq,
+    fraction::{FractionTrait, One},
+    from_int::FromUnsigned,
+    id::Id,
+    unit::UnitTrait,
+    units::Dimensionless,
+    Unit,
+};
 
 /// Base type of the whole lib
 ///

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -6,15 +6,8 @@ use core::{
     ops::{Add, Div, Mul, Neg, Sub},
 };
 
-use crate::{
-    checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub},
-    fraction::{FractionTrait, One},
-    from_int::FromUnsigned,
-    id::Id,
-    unit::UnitTrait,
-    units::Dimensionless,
-    Unit,
-};
+use crate::{checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub}, fraction::{FractionTrait, One}, from_int::FromUnsigned, id::Id, unit::UnitTrait, units::Dimensionless, Unit};
+use crate::eq::DimensionsEq;
 
 /// Base type of the whole lib
 ///
@@ -203,17 +196,7 @@ where
     pub fn to<T>(self) -> Quantity<S, T>
     where
         T: UnitTrait,
-        T::Ratio: FractionTrait,
-        // Can't use `UnitEq` because we don't need ratio to be equal
-        U: UnitTrait<
-            Length = T::Length,
-            Mass = T::Mass,
-            Time = T::Time,
-            ElectricCurrent = T::ElectricCurrent,
-            ThermodynamicTemperature = T::ThermodynamicTemperature,
-            AmountOfSubstance = T::AmountOfSubstance,
-            LuminousIntensity = T::LuminousIntensity,
-        >,
+        U::Dimensions: DimensionsEq<T::Dimensions>,
     {
         Quantity::new(T::Ratio::div(U::Ratio::mul(self.storage)))
     }
@@ -231,21 +214,7 @@ where
     #[inline]
     #[allow(clippy::wrong_self_convention)] // TODO: better name
     #[allow(clippy::type_complexity)]
-    pub fn to_base(
-        self,
-    ) -> Quantity<
-        S,
-        Unit<
-            U::Length,
-            U::Mass,
-            U::Time,
-            U::ElectricCurrent,
-            U::ThermodynamicTemperature,
-            U::AmountOfSubstance,
-            U::LuminousIntensity,
-            One,
-        >,
-    > {
+    pub fn to_base(self) -> Quantity<S, Unit<U::Dimensions, One>> {
         self.to()
     }
 }

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -39,11 +39,11 @@ where
     }
 }
 
-impl<L, M, T, I, O, N, J, R> Simplify for Unit<L, M, T, I, O, N, J, R>
+impl<D, R> Simplify for Unit<D, R>
 where
     R: Simplify,
 {
-    type Output = Unit<L, M, T, I, O, N, J, R::Output>;
+    type Output = Unit<D, R::Output>;
 
     #[inline]
     fn simplify(self) -> Self::Output {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2,10 +2,15 @@ use core::{
     any::type_name,
     fmt::{Debug, Error, Formatter},
     marker::PhantomData,
-    ops::{Add, Div, Mul, Sub},
+    ops::{Div, Mul},
 };
 
-use crate::{fraction::One, TypeOnly};
+use crate::{
+    fraction::One,
+    TypeOnly,
+    DimensionsTrait,
+    fraction::FractionTrait
+};
 
 /// Trait implemented for [`Unit`].
 /// Mostly needed to simplify bound and write
@@ -20,7 +25,7 @@ use crate::{fraction::One, TypeOnly};
 /// ```
 /// # use typed_phy::Unit;
 /// # trait Trait {}
-/// impl<L, M, T, I, O, N, J, R> Trait for Unit<L, M, T, I, O, N, J, R> {
+/// impl<D, R> Trait for Unit<D, R> {
 ///     /* ... */
 /// }
 /// ```
@@ -29,73 +34,45 @@ use crate::{fraction::One, TypeOnly};
 ///
 /// [`Unit`]: struct@Unit
 pub trait UnitTrait {
-    /// Length, base unit: metre
-    type Length;
-
-    /// Mass, base unit: kilogram
-    type Mass;
-
-    /// Time, base unit: second
-    type Time;
-
-    /// Electric current, base unit: ampere
-    type ElectricCurrent;
-
-    /// Thermodynamic temperature, base unit: kelvin
-    type ThermodynamicTemperature;
-
-    /// Amount of substance, base unit: mole
-    type AmountOfSubstance;
-
-    /// Luminous intensity, base unit: candela
-    type LuminousIntensity;
+    ///
+    type Dimensions: DimensionsTrait;
 
     /// Ratio
-    type Ratio;
+    type Ratio: FractionTrait;
 }
 
-#[rustfmt::skip] // I don't want assoc types to be reordered
-impl<L, M, T, I, O, N, J, R> UnitTrait for Unit<L, M, T, I, O, N, J, R> {
-    type Length = L;
-    type Mass = M;
-    type Time = T;
-    type ElectricCurrent = I;
-    type ThermodynamicTemperature = O;
-    type AmountOfSubstance = N;
-    type LuminousIntensity = J;
+impl<D: DimensionsTrait, R: FractionTrait> UnitTrait for Unit<D, R> {
+    type Dimensions = D;
+
     type Ratio = R;
 }
 
-/// Represent unit at type level by storing exponents of the [base units]:
-///
-/// - `L`, Length
-/// - `M`, Mass
-/// - `T`, Time
-/// - `I`, Electric current
-/// - `O` Thermodynamic temperature
-/// - `N` Amount of substance
-/// - `J` Luminous intensity
+/// Represent unit at type level by storing exponents of the [base units] in [`Dimensions`] struct
+/// and relation to the base unit in [`Fraction`] struct:
 ///
 /// Examples:
-/// - `Unit<P1, Z0, Z0, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁰ * ...` is `m` is
+/// - `Unit<Dimensions<1, 0, 0, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁰ * ...` is `m` is
 ///   metre (length).
-/// - `Unit<Z0, Z0, P1, Z0, Z0, Z0, Z0>` is `m⁰ * kg⁰ * s¹ * ...` is `s` is
+/// - `Unit<Dimensions<0, 0, 1, 0, 0, 0, 0>, 1/1>` is `m⁰ * kg⁰ * s¹ * ...` is `s` is
 ///   second (time).
-/// - `Unit<P1, Z0, N1, Z0, Z0, Z0, Z0>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m * s⁻¹`
+/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m * s⁻¹`
 ///   is `m / s` metre per second (speed)
+/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1000/3600>` is `m¹ * kg⁰ * s⁻¹ * ... * (1000/3600)` is `m * s⁻¹ * (1000/3600)`
+///   is `m / s` kilometre per hour (speed)
 ///
 /// [base units]: https://en.wikipedia.org/wiki/SI_base_unit
-#[allow(clippy::type_complexity)]
-pub struct Unit<L, M, T, I, O, N, J, R = One>(TypeOnly<(L, M, T, I, O, N, J, R)>);
+/// [`Dimensions`]: crate::Dimensions
+/// [`Fraction`]: crate::Fraction
+pub struct Unit<D, R = One>(TypeOnly<(D, R)>);
 
-impl<L, M, T, I, O, N, J, R> Unit<L, M, T, I, O, N, J, R> {
+impl<D, R> Unit<D, R> {
     pub(crate) fn new() -> Self {
         Self(PhantomData::default())
     }
 }
 
 // We need to use handwritten impls to prevent unnecessary bounds on generics
-impl<L, M, T, I, O, N, J, R> Debug for Unit<L, M, T, I, O, N, J, R> {
+impl<D, R> Debug for Unit<D, R> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         // TODO: add options to human-readable format
@@ -103,41 +80,29 @@ impl<L, M, T, I, O, N, J, R> Debug for Unit<L, M, T, I, O, N, J, R> {
     }
 }
 
-impl<L, M, T, I, O, N, J, R> Clone for Unit<L, M, T, I, O, N, J, R> {
+impl<D, R> Clone for Unit<D, R> {
     #[inline]
     fn clone(&self) -> Self {
         Self::new()
     }
 }
 
-impl<L, M, T, I, O, N, J, R> Copy for Unit<L, M, T, I, O, N, J, R> {}
+impl<D, R> Copy for Unit<D, R> {}
 
 /// This adds exponents and multiplies ratios at type-level. E.g.
 /// `Unit<1, 0, -1, ..., 1/10> * Unit<0, 0, 1, ..., 10/1> =
 /// Unit<1, 0, 0, ..., 1/1>`
 ///
 /// It's used for multiplying quantities.
-impl<U, L, M, T, I, O, N, J, R> Mul<U> for Unit<L, M, T, I, O, N, J, R>
+impl<U, D, R> Mul<U> for Unit<D, R>
 where
     U: UnitTrait,
-    L: Add<U::Length>,
-    M: Add<U::Mass>,
-    T: Add<U::Time>,
-    I: Add<U::ElectricCurrent>,
-    O: Add<U::ThermodynamicTemperature>,
-    N: Add<U::AmountOfSubstance>,
-    J: Add<U::LuminousIntensity>,
+    D: Mul<U::Dimensions>,
     R: Mul<U::Ratio>,
 {
     #[allow(clippy::type_complexity)]
     type Output = Unit<
-        <L as Add<U::Length>>::Output,
-        <M as Add<U::Mass>>::Output,
-        <T as Add<U::Time>>::Output,
-        <I as Add<U::ElectricCurrent>>::Output,
-        <O as Add<U::ThermodynamicTemperature>>::Output,
-        <N as Add<U::AmountOfSubstance>>::Output,
-        <J as Add<U::LuminousIntensity>>::Output,
+        <D as Mul<U::Dimensions>>::Output,
         <R as Mul<U::Ratio>>::Output,
     >;
 
@@ -152,28 +117,16 @@ where
 /// Unit<1, 0, -2, ..., 1/100>`
 ///
 /// It's used for dividing quantities.
-impl<U, L, M, T, I, O, N, J, R> Div<U> for Unit<L, M, T, I, O, N, J, R>
+impl<U, D, R> Div<U> for Unit<D, R>
 where
     U: UnitTrait,
-    L: Sub<U::Length>,
-    M: Sub<U::Mass>,
-    T: Sub<U::Time>,
-    I: Sub<U::ElectricCurrent>,
-    O: Sub<U::ThermodynamicTemperature>,
-    N: Sub<U::AmountOfSubstance>,
-    J: Sub<U::LuminousIntensity>,
+    D: Div<U::Dimensions>,
     R: Div<U::Ratio>,
 {
     // Yeah, it's very complex, but I can't do anything with it :(
     #[allow(clippy::type_complexity)]
     type Output = Unit<
-        <L as Sub<U::Length>>::Output,
-        <M as Sub<U::Mass>>::Output,
-        <T as Sub<U::Time>>::Output,
-        <I as Sub<U::ElectricCurrent>>::Output,
-        <O as Sub<U::ThermodynamicTemperature>>::Output,
-        <N as Sub<U::AmountOfSubstance>>::Output,
-        <J as Sub<U::LuminousIntensity>>::Output,
+        <D as Div<U::Dimensions>>::Output,
         <R as Div<U::Ratio>>::Output,
     >;
 
@@ -187,8 +140,6 @@ where
 mod tests {
     use core::fmt::Debug;
 
-    use typenum::{N2, N3, N4, N5, N6, N7, N8, P1, P2, P3, P4, P5, P6, P7, P8, Z0};
-
     use crate::Unit;
 
     /// Test that `Unit` implement `Debug + Clone + Copy`
@@ -198,27 +149,9 @@ mod tests {
     fn traits() {
         fn assert_bounds<T: Debug + Clone + Copy>(_: T) {}
 
-        fn check<L, M, T, I, O, N, J /* no bounds */>() {
+        fn check<D, R /* no bounds */>() {
             // check that traits are implemented for any generics
-            assert_bounds(Unit::<L, M, T, I, O, N, J>::new())
+            assert_bounds(Unit::<D, R>::new())
         }
-    }
-
-    #[test]
-    fn div() {
-        let _: Unit<Z0, Z0, Z0, Z0, Z0, Z0, Z0> =
-            Unit::<P1, P1, P1, P1, P1, P1, P1>::new() / Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
-
-        let _: Unit<N8, N7, N6, N5, N4, N3, N2> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() / Unit::<P8, P7, P6, P5, P4, P3, P2>::new();
-    }
-
-    #[test]
-    fn mul() {
-        let _: Unit<P1, P1, P1, P1, P1, P1, P1> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Unit::<P1, P1, P1, P1, P1, P1, P1>::new();
-
-        let _: Unit<P8, N7, P6, N5, P4, N3, P2> =
-            Unit::<Z0, Z0, Z0, Z0, Z0, Z0, Z0>::new() * Unit::<P8, N7, P6, N5, P4, N3, P2>::new();
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -6,10 +6,8 @@ use core::{
 };
 
 use crate::{
-    fraction::One,
-    TypeOnly,
-    DimensionsTrait,
-    fraction::FractionTrait
+    fraction::{FractionTrait, One},
+    DimensionsTrait, TypeOnly,
 };
 
 /// Trait implemented for [`Unit`].
@@ -43,22 +41,22 @@ pub trait UnitTrait {
 
 impl<D: DimensionsTrait, R: FractionTrait> UnitTrait for Unit<D, R> {
     type Dimensions = D;
-
     type Ratio = R;
 }
 
-/// Represent unit at type level by storing exponents of the [base units] in [`Dimensions`] struct
-/// and relation to the base unit in [`Fraction`] struct:
+/// Represent unit at type level by storing exponents of the [base units] in
+/// [`Dimensions`] struct and relation to the base unit in [`Fraction`] struct:
 ///
 /// Examples:
-/// - `Unit<Dimensions<1, 0, 0, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁰ * ...` is `m` is
-///   metre (length).
-/// - `Unit<Dimensions<0, 0, 1, 0, 0, 0, 0>, 1/1>` is `m⁰ * kg⁰ * s¹ * ...` is `s` is
-///   second (time).
-/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁻¹ * ...` is `m * s⁻¹`
-///   is `m / s` metre per second (speed)
-/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1000/3600>` is `m¹ * kg⁰ * s⁻¹ * ... * (1000/3600)` is `m * s⁻¹ * (1000/3600)`
-///   is `m / s` kilometre per hour (speed)
+/// - `Unit<Dimensions<1, 0, 0, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁰ * ...` is
+///   `m` is metre (length).
+/// - `Unit<Dimensions<0, 0, 1, 0, 0, 0, 0>, 1/1>` is `m⁰ * kg⁰ * s¹ * ...` is
+///   `s` is second (time).
+/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1/1>` is `m¹ * kg⁰ * s⁻¹ * ...` is
+///   `m * s⁻¹` is `m / s` metre per second (speed)
+/// - `Unit<Dimensions<1, 0, -1, 0, 0, 0, 0>, 1000/3600>` is `m¹ * kg⁰ * s⁻¹ *
+///   ... * (1000/3600)` is `m * s⁻¹ * (1000/3600)` is `m / s` kilometre per
+///   hour (speed)
 ///
 /// [base units]: https://en.wikipedia.org/wiki/SI_base_unit
 /// [`Dimensions`]: crate::Dimensions
@@ -101,10 +99,7 @@ where
     R: Mul<U::Ratio>,
 {
     #[allow(clippy::type_complexity)]
-    type Output = Unit<
-        <D as Mul<U::Dimensions>>::Output,
-        <R as Mul<U::Ratio>>::Output,
-    >;
+    type Output = Unit<<D as Mul<U::Dimensions>>::Output, <R as Mul<U::Ratio>>::Output>;
 
     #[inline]
     fn mul(self, _rhs: U) -> Self::Output {
@@ -125,10 +120,7 @@ where
 {
     // Yeah, it's very complex, but I can't do anything with it :(
     #[allow(clippy::type_complexity)]
-    type Output = Unit<
-        <D as Div<U::Dimensions>>::Output,
-        <R as Div<U::Ratio>>::Output,
-    >;
+    type Output = Unit<<D as Div<U::Dimensions>>::Output, <R as Div<U::Ratio>>::Output>;
 
     #[inline]
     fn div(self, _rhs: U) -> Self::Output {

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,12 +1,9 @@
 use typenum::{P1, U24, U60, Z0};
 
-use crate::{
-    prefixes::{Kilo, Milli, MulBy},
-    unit::Unit,
-};
+use crate::{prefixes::{Kilo, Milli, MulBy}, unit::Unit, Dimensions};
 
 /// Just integer.
-pub type Dimensionless = Unit<Z0, Z0, Z0, Z0, Z0, Z0, Z0>;
+pub type Dimensionless = Unit<Dimensions<Z0, Z0, Z0, Z0, Z0, Z0, Z0>>;
 
 // Base units
 
@@ -15,19 +12,19 @@ pub type Dimensionless = Unit<Z0, Z0, Z0, Z0, Z0, Z0, Z0>;
 //                 Mass ----*.  \    |    /   .*---- Amount of substance
 //           Length ---- L,  M,  T,  I,  O,  N,  J ---- Luminous intensity
 /// Metre. `m`
-pub type Metre = Unit<P1, Z0, Z0, Z0, Z0, Z0, Z0>;
+pub type Metre = Unit<Dimensions<P1, Z0, Z0, Z0, Z0, Z0, Z0>>;
 /// Kilogram. `kg`
-pub type KiloGram = Unit<Z0, P1, Z0, Z0, Z0, Z0, Z0>;
+pub type KiloGram = Unit<Dimensions<Z0, P1, Z0, Z0, Z0, Z0, Z0>>;
 /// Second. `s`
-pub type Second = Unit<Z0, Z0, P1, Z0, Z0, Z0, Z0>;
+pub type Second = Unit<Dimensions<Z0, Z0, P1, Z0, Z0, Z0, Z0>>;
 /// Ampere. `A`
-pub type Ampere = Unit<Z0, Z0, Z0, P1, Z0, Z0, Z0>;
+pub type Ampere = Unit<Dimensions<Z0, Z0, Z0, P1, Z0, Z0, Z0>>;
 /// Kelvin. `K`
-pub type Kelvin = Unit<Z0, Z0, Z0, Z0, P1, Z0, Z0>;
+pub type Kelvin = Unit<Dimensions<Z0, Z0, Z0, Z0, P1, Z0, Z0>>;
 /// Mole. `mol`
-pub type Mole = Unit<Z0, Z0, Z0, Z0, Z0, P1, Z0>;
+pub type Mole = Unit<Dimensions<Z0, Z0, Z0, Z0, Z0, P1, Z0>>;
 /// Candela. `cd`
-pub type Candela = Unit<Z0, Z0, Z0, Z0, Z0, Z0, P1>;
+pub type Candela = Unit<Dimensions<Z0, Z0, Z0, Z0, Z0, Z0, P1>>;
 
 // Derived units
 /// Radian. `rad`

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,6 +1,10 @@
 use typenum::{P1, U24, U60, Z0};
 
-use crate::{prefixes::{Kilo, Milli, MulBy}, unit::Unit, Dimensions};
+use crate::{
+    prefixes::{Kilo, Milli, MulBy},
+    unit::Unit,
+    Dimensions,
+};
 
 /// Just integer.
 pub type Dimensionless = Unit<Dimensions<Z0, Z0, Z0, Z0, Z0, Z0, Z0>>;

--- a/tests/ui/01-quantity-wrong-unit.stderr
+++ b/tests/ui/01-quantity-wrong-unit.stderr
@@ -6,5 +6,5 @@ error[E0308]: mismatched types
   |            |
   |            expected due to this
   |
-  = note: expected struct `typed_phy::quantity::Quantity<_, typed_phy::unit::Unit<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, typenum::int::NInt<typenum::uint::UInt<_, typenum::bit::B0>>, _, _, _, _>>`
-             found struct `typed_phy::quantity::Quantity<_, typed_phy::unit::Unit<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>>, _, typenum::int::NInt<typenum::uint::UInt<_, typenum::bit::B1>>, _, _, _, _>>`
+  = note: expected struct `typed_phy::quantity::Quantity<_, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, typenum::int::NInt<typenum::uint::UInt<_, typenum::bit::B0>>, _, _, _, _>>>`
+             found struct `typed_phy::quantity::Quantity<_, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>>, _, typenum::int::NInt<typenum::uint::UInt<_, typenum::bit::B1>>, _, _, _, _>>>`

--- a/tests/ui/02-quantity-wrong-storage.stderr
+++ b/tests/ui/02-quantity-wrong-storage.stderr
@@ -7,4 +7,4 @@ error[E0308]: mismatched types
   |            expected due to this
   |
   = note: expected struct `typed_phy::quantity::Quantity<u32, _>`
-             found struct `typed_phy::quantity::Quantity<i32, typed_phy::unit::Unit<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, typenum::int::Z0, typenum::int::NInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, typenum::int::Z0, typenum::int::Z0, typenum::int::Z0, typenum::int::Z0>>`
+             found struct `typed_phy::quantity::Quantity<i32, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, typenum::int::Z0, typenum::int::NInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, typenum::int::Z0, typenum::int::Z0, typenum::int::Z0, typenum::int::Z0>>>`

--- a/tests/ui/03-add-sub-wrong-unit.stderr
+++ b/tests/ui/03-add-sub-wrong-unit.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 4 |     let _ = 5.kg() + 10.sqm();
   |                      ^^^^^^^^ expected struct `typenum::int::Z0`, found struct `typenum::int::PInt`
   |
-  = note: expected struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typenum::int::Z0, typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, _, _, _, _>>`
-             found struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>>, typenum::int::Z0, _, _, _, _, _>>`
+  = note: expected struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<typenum::int::Z0, typenum::int::PInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, _, _, _, _>>>`
+             found struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<typenum::int::PInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>>, typenum::int::Z0, _, _, _, _, _>>>`
 
 error[E0308]: mismatched types
  --> $DIR/03-add-sub-wrong-unit.rs:5:22
@@ -13,5 +13,5 @@ error[E0308]: mismatched types
 5 |     let _ = 10.m() - 5.mps();
   |                      ^^^^^^^ expected struct `typenum::int::Z0`, found struct `typenum::int::NInt`
   |
-  = note: expected struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<_, _, typenum::int::Z0, _, _, _, _>>`
-             found struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<_, _, typenum::int::NInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, _, _, _>>`
+  = note: expected struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<_, _, typenum::int::Z0, _, _, _, _>>>`
+             found struct `typed_phy::quantity::Quantity<{integer}, typed_phy::unit::Unit<typed_phy::dimensions::Dimensions<_, _, typenum::int::NInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>>, _, _, _, _>>>`


### PR DESCRIPTION
Before this pr all dimensions were stored in generic parameters
in `Unit` struct, this pr moves them into another struct (`Dimensions`).

This also adds `Dimensions{Trait,Eq}` traits similar to `Unit{Trait,Eq}` and
`Fraction{Trait,Eq}`