### PR TITLE
make `TypeOnly<T>` invariant over `T`

### DIFF
--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -88,10 +88,16 @@ where
 pub struct Dimensions<L, M, T, I, O, N, J>(TypeOnly<(L, M, T, I, O, N, J)>);
 
 impl<L, M, T, I, O, N, J> Dimensions<L, M, T, I, O, N, J> {
+    /// Workaround for creating struct in const fn.
+    /// See https://github.com/rust-lang/rust/issues/69459
+    const NEW: Self = Self(PhantomData);
+}
+
+impl<L, M, T, I, O, N, J> Dimensions<L, M, T, I, O, N, J> {
     /// Create new dimensions
     #[inline]
     pub const fn new() -> Self {
-        Self(PhantomData)
+        Self::NEW
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,7 @@ pub use self::{
 };
 
 /// Invariant over `T` and doesn't own it.
-// FIXME replace back, as https://github.com/rust-lang/rust/issues/69459 would be resolved
-pub(crate) type TypeOnly<T> = core::marker::PhantomData<T>;
-//pub(crate) type TypeOnly<T> = core::marker::PhantomData<fn(T) -> T>;
+pub(crate) type TypeOnly<T> = core::marker::PhantomData<fn(T) -> T>;
 
 /// UI tests to see weird type errors.
 ///

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -65,10 +65,16 @@ impl<D: DimensionsTrait, R: FractionTrait> UnitTrait for Unit<D, R> {
 pub struct Unit<D, R = One>(TypeOnly<(D, R)>);
 
 impl<D, R> Unit<D, R> {
+    /// Workaround for creating struct in const fn.
+    /// See https://github.com/rust-lang/rust/issues/69459
+    const NEW: Self = Self(PhantomData);
+}
+
+impl<D, R> Unit<D, R> {
     /// Create new unit
     #[inline]
     pub const fn new() -> Self {
-        Self(PhantomData)
+        Self::NEW
     }
 }
 


### PR DESCRIPTION
This makes `Send`/`Sync`/etc impls simpler.