### PR TITLE
reexport `typenum::U1`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,3 +116,9 @@ fn ui() {
 #[cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #[cfg(doctest)]
 pub struct ReadmeDocTests;
+
+/// Reexport for macros
+#[doc(hidden)]
+pub mod reexport {
+    pub use typenum::U1;
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -161,11 +161,9 @@ macro_rules! Frac {
         $crate::fraction::Fraction::<$a, $b>
     };
     (/ $b:ty) => {
-        $crate::fraction::Fraction::<typenum::U1, $b>
-        //                           ^^^^^^^^^^^ TODO: crate reexport
+        $crate::fraction::Fraction::<$crate::reexport::U1, $b>
     };
     ($a:ty) => {
-        $crate::fraction::Fraction::<$a, typenum::U1>
-        //                              ^^^^^^^^^^^ TODO: crate reexport
+        $crate::fraction::Fraction::<$a, $crate::reexport::U1>
     };
 }


### PR DESCRIPTION
Reexport `typenum::U1` so `Frac!` macro won't break
without `typenum` dependency in user's crate