### PR TITLE
fix the badges in the readme and add install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the crate isn't published on crates.io yet, so to use it spicify it as a git dep
 
 ```toml
 [dependencies]
-# Replace <...> with commit you want to use (it is recomended to use the lates commit)
+# Replace <...> with commit you want to use (it is recomended to use the latest commit)
 typed_phy = { git = "https://github.com/WaffleLapkin/typed_phy", rev = "<...>" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,16 @@
 
 [![CI status](https://github.com/WaffleLapkin/typed_phy/workflows/Continuous%20integration/badge.svg)](https://github.com/WaffleLapkin/arraylib/actions)
 [![Telegram](https://img.shields.io/badge/tg-WaffleLapkin-9cf?logo=telegram)](https://vee.gg/t/WaffleLapkin)
-[![docs.rs](https://img.shields.io/badge/docs.rs-typed_phy-blue.svg)](https://docs.rs/typed_phy)
+[![documentation (master)](https://img.shields.io/badge/docs-master-blue)](https://typed-phy.netlify.com/typed_phy)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![crates.io](https://img.shields.io/badge/crates.io-v0.1.0-orange.svg)](https://crates.io/crates/typed_phy)
+
+
+
+<!--
+(commented until release)
+[![crates.io](http://meritbadge.herokuapp.com/typed_phy)](https://crates.io/crates/typed_phy)
+[![documentation (docs.rs)](https://docs.rs/typed_phy/badge.svg)](https://docs.rs/typed_phy)
+-->
 
 This is a lib for working with typed physical quantities.
 It ensures at compile time that you couldn't add meters to seconds or do other weird stuff.
@@ -19,6 +26,14 @@ let time = 2.s() * 3;
 let speed = length / time;
 
 assert_eq!(speed, 4.mps());
+```
+
+the crate isn't published on crates.io yet, so to use it spicify it as a git dependency:
+
+```toml
+[dependencies]
+# Replace <...> with commit you want to use (it is recomended to use the lates commit)
+typed_phy = { git = "https://github.com/WaffleLapkin/typed_phy", rev = "<...>" }
 ```
 
 ## Warning


### PR DESCRIPTION
this commit
- removes (comments) crates.io and docs.rs badges because they are useless before the first release
- adds docs|master badge
- adds a note about how to install typed_phy into your project