### PR TITLE
implement a lot of traits for `Quantity`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_test = "1.0"
 # Default features is a strange thing - to remove them _all_ crates in the dep tree
 # those depend on the crate must disable them...
 default = []
-# Curetly used only for readme doc tests
+# Curetly used only for readme doc tests & `impl Step for Quantity`
 nightly = []
 # Enables (de)serialization through `serde` (derives `(De)Serialize` traits on `Quantity`)
 deser = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@
 //! - `deser` - enables support of (de)serializing [`Quantity`] via [`serde`]
 //! - `nightly` - enables features those require nightly compiler. Currently
 //!   those are:
-//!   - [`impl core::iter::Step for Quantity`](crate::Quantity#impl-Step)
+//!   - ~~[`impl core::iter::Step for Quantity`](crate::Quantity#impl-Step)~~
+//!     (TODO: this implementation was removed because of a breaking change in
+//!     std, later on, we will need to implement this again)
 //!   - that's all :)
 //!
 //! [`Quantity`]: crate::Quantity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,10 @@
 //! ## cargo features
 //!
 //! - `deser` - enables support of (de)serializing [`Quantity`] via [`serde`]
+//! - `nightly` - enables features those require nightly compiler. Currently
+//!   those are:
+//!   - [`impl core::iter::Step for Quantity`](crate::Quantity#impl-Step)
+//!   - that's all :)
 //!
 //! [`Quantity`]: crate::Quantity
 //! [`serde`]: https://docs.rs/serde
@@ -61,7 +65,7 @@
 // For running tests from readme
 #![cfg_attr(all(doctest, feature = "nightly"), feature(external_doc))]
 //explain TODO
-#![cfg_attr(feature = "nightly", feature(doc_cfg))]
+#![cfg_attr(feature = "nightly", feature(doc_cfg, step_trait))]
 // I hate missing docs
 #![deny(missing_docs)]
 // And I like inline

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -817,26 +817,32 @@ impl<S, U> Step for Quantity<S, U>
 where
     S: Step,
 {
+    #[inline]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         <_>::steps_between(&start.storage, &end.storage)
     }
 
+    #[inline]
     fn replace_one(&mut self) -> Self {
         Self::new(self.storage.replace_one())
     }
 
+    #[inline]
     fn replace_zero(&mut self) -> Self {
         Self::new(self.storage.replace_zero())
     }
 
+    #[inline]
     fn add_one(&self) -> Self {
         Self::new(self.storage.add_one())
     }
 
+    #[inline]
     fn sub_one(&self) -> Self {
         Self::new(self.storage.sub_one())
     }
 
+    #[inline]
     fn add_usize(&self, n: usize) -> Option<Self> {
         self.storage.add_usize(n).map(Self::new)
     }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -6,8 +6,8 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
 };
 
-#[cfg(feature = "nightly")]
-use core::iter::Step;
+// #[cfg(feature = "nightly")]
+// use core::iter::Step;
 
 use typenum::{Prod, Quot};
 
@@ -812,41 +812,41 @@ where
     }
 }
 
-#[cfg(feature = "nightly")]
-impl<S, U> Step for Quantity<S, U>
-where
-    S: Step,
-{
-    #[inline]
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        <_>::steps_between(&start.storage, &end.storage)
-    }
-
-    #[inline]
-    fn replace_one(&mut self) -> Self {
-        Self::new(self.storage.replace_one())
-    }
-
-    #[inline]
-    fn replace_zero(&mut self) -> Self {
-        Self::new(self.storage.replace_zero())
-    }
-
-    #[inline]
-    fn add_one(&self) -> Self {
-        Self::new(self.storage.add_one())
-    }
-
-    #[inline]
-    fn sub_one(&self) -> Self {
-        Self::new(self.storage.sub_one())
-    }
-
-    #[inline]
-    fn add_usize(&self, n: usize) -> Option<Self> {
-        self.storage.add_usize(n).map(Self::new)
-    }
-}
+// #[cfg(feature = "nightly")]
+// impl<S, U> Step for Quantity<S, U>
+// where
+//     S: Step,
+// {
+//     #[inline]
+//     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+//         <_>::steps_between(&start.storage, &end.storage)
+//     }
+//
+//     #[inline]
+//     fn replace_one(&mut self) -> Self {
+//         Self::new(self.storage.replace_one())
+//     }
+//
+//     #[inline]
+//     fn replace_zero(&mut self) -> Self {
+//         Self::new(self.storage.replace_zero())
+//     }
+//
+//     #[inline]
+//     fn add_one(&self) -> Self {
+//         Self::new(self.storage.add_one())
+//     }
+//
+//     #[inline]
+//     fn sub_one(&self) -> Self {
+//         Self::new(self.storage.sub_one())
+//     }
+//
+//     #[inline]
+//     fn add_usize(&self, n: usize) -> Option<Self> {
+//         self.storage.add_usize(n).map(Self::new)
+//     }
+// }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
implement these traits for `Quantity`:
- `Hash`
- `{Add,Sub}Assign<Self>`
- `{Mul,Div}Assign<S>`
- `Rem{,Assign}<S>`
- `Rem<Quantity<_, _>>`
- `Binary`, `LowerExp`, `LowerHex`, `Octal`, `UpperExp`, `UpperHex` (`Display`-like traits)
- `From<S>`
- `core::iter::Step` (only with `nightly` feature)